### PR TITLE
support for subject_flagged metadata

### DIFF
--- a/.approvals
+++ b/.approvals
@@ -1,0 +1,1 @@
+spec/fixtures/approvals/wildlife_watch/processes_workflow_1810.approved.txt spec/fixtures/approvals/wildlife_watch/processes_workflow_1810.received.txt

--- a/lib/nero/algorithm.rb
+++ b/lib/nero/algorithm.rb
@@ -7,13 +7,11 @@ module Nero
       @panoptes = panoptes
       @options = options
     end
-    
-    def process(classification, user_state, subject_state )
+
+    def process(classification, _user_state, subject_state)
       if classification.flagged?
         panoptes.retire(subject_state)
       end
-
-      return []
     end
   end
 end

--- a/lib/nero/algorithm.rb
+++ b/lib/nero/algorithm.rb
@@ -9,7 +9,7 @@ module Nero
     end
 
     def process(classification, _user_state, subject_state)
-      if classification.flagged?
+      if classification.user_id && classification.flagged?
         panoptes.retire(subject_state)
       end
     end

--- a/lib/nero/algorithm.rb
+++ b/lib/nero/algorithm.rb
@@ -1,9 +1,19 @@
 module Nero
   class Algorithm
+    attr_reader :storage, :panoptes, :options
+
     def initialize(storage, panoptes, options = {})
       @storage = storage
       @panoptes = panoptes
       @options = options
+    end
+    
+    def process(classification, user_state, subject_state )
+      if classification.flagged?
+        panoptes.retire(subject_state)
+      end
+
+      return []
     end
   end
 end

--- a/lib/nero/classification.rb
+++ b/lib/nero/classification.rb
@@ -7,6 +7,10 @@ module Nero
       @linked = linked
     end
 
+    def flagged?
+      hash.fetch("metadata", {}).fetch("subject_flagged", false)
+    end
+
     def id
       hash.fetch("id")
     end

--- a/lib/nero/equador/equador_algorithm.rb
+++ b/lib/nero/equador/equador_algorithm.rb
@@ -4,7 +4,7 @@ require_relative 'equador_subject_state'
 module Nero
   module Equador
     class EquadorAlgorithm < Nero::Algorithm
-      def process(classification, _user_state, subject_state)
+      def process(classification, user_state, subject_state)
         super(classification, user_state, subject_state)
         return unless classification.user_id
         return unless classification.subject_ids.size == 1

--- a/lib/nero/equador/equador_algorithm.rb
+++ b/lib/nero/equador/equador_algorithm.rb
@@ -5,6 +5,7 @@ module Nero
   module Equador
     class EquadorAlgorithm < Nero::Algorithm
       def process(classification, _user_state, subject_state)
+        super(classification, user_state, subject_state)
         return unless classification.user_id
         return unless classification.subject_ids.size == 1
 

--- a/lib/nero/processor.rb
+++ b/lib/nero/processor.rb
@@ -7,12 +7,6 @@ module Nero
   class Processor
     include ::NewRelic::Agent::Instrumentation::ControllerInstrumentation
 
-    class NullAlgorithm
-      def process(*args)
-        return []
-      end
-    end
-
     ALGORITHMS = {
       'wildlife_watch' => Nero::WildlifeWatch::WildlifeWatchAlgorithm,
       'swap' => Nero::Swap::SwapAlgorithm,
@@ -25,7 +19,7 @@ module Nero
     def initialize(storage, output, config)
       @storage = storage
       @output  = output
-      @workflows = config.each.with_object(Hash.new(NullAlgorithm.new)) do |(workflow_id, workflow_config), hash|
+      @workflows = config.each.with_object(Hash.new(Algorithm.new(@storage, @output))) do |(workflow_id, workflow_config), hash|
         hash[workflow_id.to_s] = ALGORITHMS.fetch(workflow_config.fetch('algorithm')).new(storage, output, workflow_config)
       end
     end

--- a/lib/nero/pulsar_hunters/pulsar_hunters_algorithm.rb
+++ b/lib/nero/pulsar_hunters/pulsar_hunters_algorithm.rb
@@ -5,6 +5,7 @@ module Nero
   module PulsarHunters
     class PulsarHuntersAlgorithm < Nero::Algorithm
       def process(classification, user_state, subject_state)
+        super(classification, user_state, subject_state)
         return unless classification.subject_ids.size == 1
 
         classification = Nero::PulsarHunters::PulsarHuntersClassification.new(classification)

--- a/lib/nero/swap/swap_algorithm.rb
+++ b/lib/nero/swap/swap_algorithm.rb
@@ -8,6 +8,7 @@ module Nero
   module Swap
     class SwapAlgorithm < Nero::Algorithm
       def process(classification, user_state, subject_state)
+        super(classification, user_state, subject_state)
         return unless classification.user_id
 
         classification = SwapClassification.new(classification)

--- a/lib/nero/wildlife_watch/wildlife_watch_algorithm.rb
+++ b/lib/nero/wildlife_watch/wildlife_watch_algorithm.rb
@@ -5,6 +5,7 @@ module Nero
   module WildlifeWatch
     class WildlifeWatchAlgorithm < Nero::Algorithm
       def process(classification, user_state, subject_state)
+        super(classification, user_state, subject_state)
         return unless classification.user_id
         return unless classification.subject_ids.size == 1
 

--- a/spec/nero/algorithm_spec.rb
+++ b/spec/nero/algorithm_spec.rb
@@ -6,7 +6,7 @@ describe Nero::Algorithm do
   let(:subject_state) { double("SubjectState") }
   let(:output) { double("Output", retire: nil) }
   let(:config) { {} }
-  let(:algorithm){ described_class.new(storage, output) }
+  let(:algorithm) { described_class.new(storage, output) }
 
   let(:classification) do
     Nero::Classification.new(
@@ -26,5 +26,4 @@ describe Nero::Algorithm do
     algorithm.process(classification, user_state, subject_state)
     expect(output).to have_received(:retire).with(subject_state).once
   end
-
 end

--- a/spec/nero/algorithm_spec.rb
+++ b/spec/nero/algorithm_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe Nero::Algorithm do
+  let(:storage) { double("Storage", find_agent: nil, find_estimate: nil) }
+  let(:user_state) { double("UserState") }
+  let(:subject_state) { double("SubjectState") }
+  let(:output) { double("Output", retire: nil) }
+  let(:config) { {} }
+  let(:algorithm){ described_class.new(storage, output) }
+
+  let(:classification) do
+    Nero::Classification.new(
+      "id" => "classification-1",
+      "metadata" => {
+        "subject_flagged" => true
+      },
+      "links" => {
+        "project" => "project-1",
+        "workflow" => "workflow-1",
+        "user" => "user-1",
+        "subjects" => ["subject-1"]
+      })
+  end
+
+  it 'retires the subject if it is flagged' do
+    algorithm.process(classification, user_state, subject_state)
+    expect(output).to have_received(:retire).with(subject_state).once
+  end
+
+end

--- a/spec/nero/algorithm_spec.rb
+++ b/spec/nero/algorithm_spec.rb
@@ -26,4 +26,10 @@ describe Nero::Algorithm do
     algorithm.process(classification, user_state, subject_state)
     expect(output).to have_received(:retire).with(subject_state).once
   end
+
+  it 'does not retire the subject if the flag was not set by a logged-in user' do
+    classification.hash['links']['user'] = nil
+    algorithm.process(classification, user_state, subject_state)
+    expect(output).to have_received(:retire).with(subject_state).exactly(0).times
+  end
 end

--- a/spec/nero/processor_spec.rb
+++ b/spec/nero/processor_spec.rb
@@ -8,7 +8,7 @@ describe Nero::Processor do
   let(:processed_classifications) { [] }
 
   before do
-    allow_any_instance_of(Nero::Processor::NullAlgorithm).to receive(:process) do |obj, classification, user_state, subject_state|
+    allow_any_instance_of(Nero::Algorithm).to receive(:process) do |_obj, classification, _user_state, _subject_state|
       processed_classifications << classification
     end
   end
@@ -40,14 +40,14 @@ describe Nero::Processor do
   end
 
   it 'notifies Honeybadger in case a workflow implementation crashes' do
-    always_crashes = Class.new do
+    always_crashes = Class.new(Nero::Algorithm) do
       def process(*args)
         raise 'Oops'
       end
     end
 
     stub_const("Honeybadger", double("Honey Badger").as_null_object)
-    stub_const("Nero::Processor::NullAlgorithm", always_crashes)
+    stub_const("Nero::Algorithm", always_crashes)
 
     processor = described_class.new(storage, output, config)
     processor.process(data)

--- a/spec/nero/swap/swap_algorithm_spec.rb
+++ b/spec/nero/swap/swap_algorithm_spec.rb
@@ -6,7 +6,7 @@ describe Nero::Swap::SwapAlgorithm do
   let(:storage) { Nero::Storage.new(DB) }
   let(:panoptes) { spy("Panoptes") }
   let(:subj) { double("Subject", attributes: {"metadata" => {"training" => [{"type" => "lensing cluster"}]}}) }
-  let(:classification) { double("Classification", user_id: 1, subjects: [subj], hash: {"annotations" => []}) }
+  let(:classification) { double("Classification", user_id: 1, flagged?: false, subjects: [subj], hash: {"annotations" => []}) }
   let(:user_state) { double(id: 1, data: {"pl" => 0.9, "pd" => 0.9}, attributes: {}, external_id: '1') }
   let(:subject_state) { Nero::SubjectState.new(id: nil, subject_id: 1, workflow_id: 2, data: {}) } # active?: true, retired?: false, adjust: new_subject_state) }
 


### PR DESCRIPTION
If the value subject_flagged on the metadata for a classification is set to true, immediately retire the subject. This is to support the ability for disturbing images to be removed from the viewer.
